### PR TITLE
Add TypeScript implementation and npm package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,7 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Node
+node_modules/
+dist-cjs/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "graph-json",
+  "version": "0.1.0",
+  "description": "Graph-JSON encoder/decoder in TypeScript",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/yourname/graph-json"
+  },
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json && tsc -p tsconfig.cjs.json && mv dist-cjs/index.js dist/index.cjs && rm -r dist-cjs",
+    "test": "npm run build && node test/test.cjs"
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,157 @@
+const MAX_REF_ID = 2 ** 31;
+
+function isPrimitive(value: any): boolean {
+  return value === null || typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean';
+}
+
+export function deflate(value: any): any {
+  const seen = new Map<any, { refId: number | null; proxy: any }>();
+  let counter = 0;
+  const stack: Array<{ node: any; parent: any; key: any }> = [{ node: value, parent: null, key: null }];
+  let result: any = undefined;
+
+  while (stack.length) {
+    const { node, parent, key } = stack.pop()!;
+    let out: any;
+
+    if (isPrimitive(node)) {
+      out = node;
+    } else {
+      const entry = seen.get(node);
+      if (entry) {
+        if (entry.refId === null) {
+          counter += 1;
+          if (counter > MAX_REF_ID) {
+            throw new Error('ref id overflow');
+          }
+          entry.refId = counter;
+          const proxy = entry.proxy;
+          if (Array.isArray(proxy)) {
+            proxy.unshift({ '#': counter });
+          } else {
+            proxy['#'] = counter;
+          }
+        }
+        out = { '#': entry.refId };
+      } else if (Array.isArray(node)) {
+        const proxy: any[] = [];
+        seen.set(node, { refId: null, proxy });
+        out = proxy;
+        for (let i = node.length - 1; i >= 0; i--) {
+          stack.push({ node: node[i], parent: proxy, key: null });
+        }
+      } else if (typeof node === 'object') {
+        const proxy: Record<string, any> = {};
+        seen.set(node, { refId: null, proxy });
+        out = proxy;
+        const entries = Object.entries(node);
+        for (let i = entries.length - 1; i >= 0; i--) {
+          let [k, v] = entries[i];
+          let key2 = k;
+          if (/^#+$/.test(key2)) {
+            key2 = '#' + key2;
+          }
+          stack.push({ node: v, parent: proxy, key: key2 });
+        }
+      } else {
+        throw new TypeError(`Unsupported type: ${typeof node}`);
+      }
+    }
+
+    if (parent === null) {
+      result = out;
+    } else if (Array.isArray(parent)) {
+      parent.push(out);
+    } else {
+      parent[key] = out;
+    }
+  }
+
+  return result;
+}
+
+export function inflate(value: any): any {
+  const refMap = new Map<number, any>();
+
+  function walk(node: any): any {
+    if (isPrimitive(node)) {
+      return node;
+    }
+    if (Array.isArray(node)) {
+      const items = node;
+      if (
+        items.length &&
+        typeof items[0] === 'object' &&
+        items[0] !== null &&
+        Object.keys(items[0]).length === 1 &&
+        '#' in items[0]
+      ) {
+        const n = (items[0] as any)['#'];
+        if (!Number.isInteger(n) || n <= 0 || n > MAX_REF_ID) {
+          throw new Error('invalid ref id');
+        }
+        let out: any;
+        if (refMap.has(n)) {
+          out = refMap.get(n);
+        } else {
+          out = [];
+          refMap.set(n, out);
+        }
+        for (let i = 1; i < items.length; i++) {
+          out.push(walk(items[i]));
+        }
+        return out;
+      }
+      return items.map(walk);
+    }
+    if (typeof node === 'object' && node !== null) {
+      const keys = Object.keys(node);
+      if (keys.length === 1 && keys[0] === '#') {
+        const n = (node as any)['#'];
+        const existing = refMap.get(n);
+        if (!existing) {
+          throw new Error('unknown ref id');
+        }
+        return existing;
+      }
+      let n: number | undefined;
+      let obj: Record<string, any> = node as any;
+      if ('#' in obj) {
+        const value = obj['#'];
+        if (!Number.isInteger(value) || value <= 0 || value > MAX_REF_ID) {
+          throw new Error('invalid ref id');
+        }
+        n = value;
+        obj = { ...obj };
+        delete obj['#'];
+      }
+      let out: any = {};
+      if (n !== undefined) {
+        if (refMap.has(n)) {
+          out = refMap.get(n);
+        } else {
+          refMap.set(n, out);
+        }
+      }
+      for (const [k, v] of Object.entries(obj)) {
+        let key = k;
+        if (/^#+$/.test(key)) {
+          key = key.slice(1);
+        }
+        out[key] = walk(v);
+      }
+      return out;
+    }
+    throw new TypeError(`Unsupported type: ${typeof node}`);
+  }
+
+  return walk(value);
+}
+
+export function dumps(value: any, replacer?: any, space?: string | number): string {
+  return JSON.stringify(deflate(value), replacer, space);
+}
+
+export function loads(text: string): any {
+  return inflate(JSON.parse(text));
+}

--- a/test/test.cjs
+++ b/test/test.cjs
@@ -1,0 +1,27 @@
+const assert = require('node:assert');
+const { dumps, loads } = require('../dist/index.cjs');
+
+function testSelfLoop() {
+  const a = {};
+  a.self = a;
+  const data = dumps(a);
+  const b = loads(data);
+  assert.strictEqual(b, b.self);
+}
+
+function testSharedSubobject() {
+  const left = {};
+  const right = {};
+  left.buddy = right;
+  right.buddy = left;
+  const root = { left, right };
+  const data = dumps(root);
+  const obj = loads(data);
+  assert.strictEqual(obj.left.buddy, obj.right);
+  assert.strictEqual(obj.right.buddy, obj.left);
+}
+
+testSelfLoop();
+testSharedSubobject();
+
+console.log('tests passed');

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "declaration": false,
+    "outDir": "dist-cjs"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- implement Graph-JSON deflate/inflate functions in TypeScript
- add npm package metadata and build configs for ESM and CJS outputs
- include simple Node tests and ignore node artifacts

## Testing
- `npm test`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c76eba5c3483299db9ca7c7907bd11